### PR TITLE
Delete test data

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/runner/ContinuousOnlineHearingTests.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/runner/ContinuousOnlineHearingTests.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ActiveProfiles;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = {"src/aat/resources/cucumber/online-hearing.feature"},
+@CucumberOptions(features = {"src/aat/resources/cucumber"},
         format = {"pretty", "html:target/reports/cucumber/html",
                 "json:target/cucumber.json", "usage:target/usage.jsonx", "junit:target/junit.xml"},
         glue = {"uk/gov/hmcts/reform/coh/functional/bdd/steps"})

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/runner/ContinuousOnlineHearingTests.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/runner/ContinuousOnlineHearingTests.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ActiveProfiles;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = {"src/aat/resources/cucumber"},
+@CucumberOptions(features = {"src/aat/resources/cucumber/online-hearing.feature"},
         format = {"pretty", "html:target/reports/cucumber/html",
                 "json:target/cucumber.json", "usage:target/usage.jsonx", "junit:target/junit.xml"},
         glue = {"uk/gov/hmcts/reform/coh/functional/bdd/steps"})

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.coh.functional.bdd.steps;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import cucumber.api.java.After;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
@@ -17,18 +18,17 @@ import uk.gov.hmcts.reform.coh.controller.answer.AnswerRequest;
 import uk.gov.hmcts.reform.coh.controller.answer.AnswerResponse;
 import uk.gov.hmcts.reform.coh.domain.Answer;
 import uk.gov.hmcts.reform.coh.domain.Question;
-import uk.gov.hmcts.reform.coh.repository.QuestionStateRepository;
+import uk.gov.hmcts.reform.coh.service.AnswerService;
 import uk.gov.hmcts.reform.coh.service.QuestionService;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
 @ContextConfiguration
 @SpringBootTest
-public class AnswerSteps extends BaseSteps{
+public class AnswerSteps extends BaseSteps {
 
     private TestRestTemplate restTemplate = new TestRestTemplate();
 
@@ -36,33 +36,57 @@ public class AnswerSteps extends BaseSteps{
 
     private String endpoint;
 
-    private Long questionId;
+    private Long currentQuestionId;
 
-    private Long answerId;
+    private Long currentAnswerId;
 
     private Map<String, String> endpoints = new HashMap<String, String>();
 
     private AnswerRequest answerRequest;
 
+    private List<Long> questionIds;
+
+    private List<Long> answerIds;
+
     @Autowired
     private QuestionService questionService;
 
     @Autowired
-    private QuestionStateRepository questionStateRepository;
+    private AnswerService answerService;
 
     @Before
     public void setup() {
         endpoints.put("answer", "/online-hearings/1/questions/question_id/answers");
         endpoints.put("question", "/online-hearings/1/questions");
-        questionId = null;
-        answerId = null;
+
+        currentQuestionId = null;
+        currentAnswerId = null;
+
+        questionIds = new ArrayList<>();
+        answerIds = new ArrayList<>();
     }
 
-    @Given("^a valid question$")
+    @After
+    public void cleanup() {
+        /**
+         * For each test run, answers are attached to questions. These need
+         * to be deleted after test completion. Delete in reverse order for
+         * FK constrains
+         */
+        for (Long answerId : answerIds) {
+            answerService.deleteAnswer(new Answer().answerId(answerId));
+        }
+
+        for (Long questionId : questionIds) {
+            questionService.deleteQuestion(new Question().questionId(questionId));
+        }
+    }
+
     /**
      * Creates a question to be used for testing with an answer
      */
-    public void an_existing_question_with_id() throws IOException {
+    @Given("^a valid question$")
+    public void an_existing_question() throws IOException {
         Question question = new Question();
         question.setSubject("foo");
         question.setQuestionText("question text");
@@ -74,7 +98,8 @@ public class AnswerSteps extends BaseSteps{
         response = restTemplate.exchange(baseUrl + endpoints.get("question"), HttpMethod.POST, request, String.class);
         String json = response.getBody();
         question = (Question) JsonUtils.toObjectFromJson(json, Question.class);
-        this.questionId = question.getQuestionId();
+        this.currentQuestionId = question.getQuestionId();
+        questionIds.add(question.getQuestionId());
     }
 
     @Given("^a standard answer$")
@@ -100,8 +125,7 @@ public class AnswerSteps extends BaseSteps{
 
     @Given("^an unknown answer identifier$")
     public void an_unknown_answer_identifier$() throws Throwable {
-        // Write code here that turns the phrase above into concrete actions
-        answerId = 0L;
+        currentAnswerId = 0L;
     }
 
     @Given("^the endpoint is for submitting an (.*)$")
@@ -109,11 +133,11 @@ public class AnswerSteps extends BaseSteps{
         if (endpoints.containsKey(entity)) {
             // See if we need to fix the endpoint
             this.endpoint = endpoints.get(entity);
-            endpoint = endpoint.replaceAll("question_id", questionId == null ? "0" : questionId.toString());
+            endpoint = endpoint.replaceAll("question_id", currentQuestionId == null ? "0" : currentQuestionId.toString());
         }
 
-        if ("answer".equalsIgnoreCase(entity) && answerId != null) {
-            endpoint += "/" + answerId;
+        if ("answer".equalsIgnoreCase(entity) && currentAnswerId != null) {
+            endpoint += "/" + currentAnswerId;
         }
     }
 
@@ -122,7 +146,7 @@ public class AnswerSteps extends BaseSteps{
         if (endpoints.containsKey(entity)) {
             // See if we need to fix the endpoint
             this.endpoint = endpoints.get(entity);
-            endpoint = endpoint.replaceAll("question_id", questionId == null ? "0" : questionId.toString());
+            endpoint = endpoint.replaceAll("question_id", currentQuestionId == null ? "0" : currentQuestionId.toString());
         }
     }
 
@@ -139,7 +163,7 @@ public class AnswerSteps extends BaseSteps{
     @When("^a (.*) request is sent$")
     public void send_request(String type) throws IOException {
 
-        String json = convertToJson(answerRequest);
+        String json = JsonUtils.toJson(answerRequest);
 
         HttpHeaders header = new HttpHeaders();
         header.add("Content-Type", "application/json");
@@ -157,6 +181,11 @@ public class AnswerSteps extends BaseSteps{
             HttpEntity<String> request = new HttpEntity<>(json, header);
             response = restTemplate.exchange(baseUrl + endpoint + "?_method=patch", HttpMethod.POST, request, String.class);
         }
+
+        Optional<Long> optAnswerId = getAnswerId(response.getBody());
+        if (optAnswerId.isPresent()) {
+            answerIds.add(optAnswerId.get());
+        }
     }
 
     @Then("^the response code is (\\d+)$")
@@ -166,18 +195,10 @@ public class AnswerSteps extends BaseSteps{
 
     @Then("^there are (\\d+) answers$")
     public void there_are_count_answers(int count) throws Throwable {
-        ObjectMapper mapper = new ObjectMapper();
-        String json =response.getBody();
-        Answer[] myObjects = mapper.readValue(json, Answer[].class);
+        String json = response.getBody();
+        Answer[] myObjects = (Answer[]) JsonUtils.toObjectFromJson(json, Answer[].class);
 
         assertEquals("Response status code", myObjects.length, count);
-    }
-
-    private String convertToJson(Object obj) throws IOException {
-
-        ObjectMapper mapper = new ObjectMapper();
-
-        return mapper.writeValueAsString(obj);
     }
 
     private Object convertToClass(String json) throws IOException {
@@ -185,5 +206,32 @@ public class AnswerSteps extends BaseSteps{
         ObjectMapper mapper = new ObjectMapper();
 
         return mapper.readValue(json, AnswerResponse.class);
+    }
+
+    /**
+     * This will work out which type of entity has been returned and get the
+     * answer id from it
+     *
+     * @param json
+     * @return
+     */
+    private Optional<Long> getAnswerId(String json) throws IOException {
+
+        if (json == null) {
+            return Optional.empty();
+        }
+
+        Long answerId = null;
+        if (json.indexOf("question_id") > 0) {
+            Answer answer = (Answer) JsonUtils.toObjectFromJson(json, Answer.class);
+            answerId = answer.getAnswerId();
+        } else {
+            if (!json.startsWith("[")) {
+                AnswerResponse answerResponse = (AnswerResponse) JsonUtils.toObjectFromJson(json, AnswerResponse.class);
+                answerId = answerResponse.getAnswerId();
+            }
+        }
+
+        return Optional.ofNullable(answerId);
     }
 }

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.coh.functional.bdd.steps;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -15,7 +13,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
-import springfox.documentation.spring.web.json.Json;
 import uk.gov.hmcts.reform.coh.controller.answer.AnswerRequest;
 import uk.gov.hmcts.reform.coh.controller.answer.AnswerResponse;
 import uk.gov.hmcts.reform.coh.domain.Answer;

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/ApiSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/ApiSteps.java
@@ -21,8 +21,8 @@ import uk.gov.hmcts.reform.coh.service.OnlineHearingService;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -40,28 +40,17 @@ public class ApiSteps extends BaseSteps {
     private String responseString;
     private CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
-    private Set<String> newObjects;
-    private Set<OnlineHearing> newOnlineHearings;
+    private Set<String> externalRefs;
 
     @Before
     public void setup(){
-        newObjects = new HashSet<String>();
-        newOnlineHearings = new HashSet<OnlineHearing>();
+        externalRefs = new HashSet<String>();
     }
 
     @After
     public void cleanUp() {
-//        for (String object : newObjects) {
-//            OnlineHearing onlineHearing = new OnlineHearing();
-//            onlineHearing.setExternalRef(object);
-//            onlineHearingService.deleteOnlineHearingByExternalRef(onlineHearing);
-//        }
-
-        for (OnlineHearing oh : newOnlineHearings) {
-            Optional<OnlineHearing> opt = onlineHearingService.retrieveOnlineHearing(oh);
-            if (opt.isPresent()) {
-                onlineHearingService.deleteOnlineHearing(oh);
-            }
+        for (String externalRef : externalRefs) {
+            onlineHearingService.deleteByExternalRef(externalRef);
         }
     }
 
@@ -69,7 +58,7 @@ public class ApiSteps extends BaseSteps {
     public void sscs_prepare_a_json_request_with_the_field_set_to(String fieldName, String fieldInput) throws Throwable {
         json = new JSONObject();
         json.put(fieldName, fieldInput);
-        newObjects.add(fieldInput);
+        externalRefs.add(fieldInput);
     }
 
     @When("^a get request is sent to ' \"([^\"]*)\"'$")
@@ -89,7 +78,6 @@ public class ApiSteps extends BaseSteps {
         response = httpClient.execute(request);
         responseString = new BasicResponseHandler().handleResponse(response);
         OnlineHearing oh = (OnlineHearing) JsonUtils.toObjectFromJson(responseString, OnlineHearing.class);
-        newOnlineHearings.add(oh);
     }
 
     @Then("^the client receives a (\\d+) status code$")
@@ -104,5 +92,4 @@ public class ApiSteps extends BaseSteps {
     public void the_response_contains_the_following_text(String text) {
         assertTrue(responseString.contains(text));
     }
-
 }

--- a/src/aat/resources/application.yaml
+++ b/src/aat/resources/application.yaml
@@ -1,3 +1,27 @@
+spring:
+  application:
+    name: Continuous Online Hearing
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQL94Dialect
+    database: postgresql
+    show-sql: ${SHOW_SQL:true}
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate:
+        temp:
+          use_jdbc_metadata_defaults: false
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/coh}
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD:user}
+    platform: postgresql
+    tomcat:
+      max-active: ${MAX_ACTIVE_DB_CONNECTIONS:50} # Maximum number of active connections that can be allocated from this pool at the same time.
+      max-idle: ${MAX_IDLE_DB_CONNECTIONS:25}
+      max-wait: ${MAX_WAIT_DB_CONNECTIONS:10000} # Number of ms to wait before throwing an exception if no connection is available.
+      test-on-borrow: ${TEST_ON_BORROW_DB_CONNECTION:true} # Validate the connection before borrowing it from the pool.
 base-urls:
   idam-user: ${IDAM_API_URL:http://localhost:4501}
   idam-s2s: ${S2S_URL:http://localhost:4502}

--- a/src/aat/resources/cucumber/online-hearing.feature
+++ b/src/aat/resources/cucumber/online-hearing.feature
@@ -3,7 +3,7 @@ Feature: Online hearing
   Scenario: Create online hearing
     Given SSCS prepare a json request with the ' "externalRef"' field set to ' "CucumberExternalRefTestCreate" '
     When a post request is sent to ' "/online-hearings/"'
-    Then the client receives a 200 status code 
+    Then the client receives a 200 status code
     And the response contains the following text '"onlineHearingId" '
     And the response contains the following text '"CucumberExternalRefTestCreate" '
 

--- a/src/main/java/uk/gov/hmcts/reform/coh/domain/Question.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/domain/Question.java
@@ -138,4 +138,9 @@ public class Question {
     public void setQuestionState(QuestionState questionState) {
         this.questionState = questionState;
     }
+
+    public Question questionId(Long questionId) {
+        this.questionId = questionId;
+        return this;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/coh/repository/OnlineHearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/repository/OnlineHearingRepository.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.coh.repository;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.coh.domain.OnlineHearing;
 
 import java.util.Optional;
@@ -11,5 +12,7 @@ import java.util.UUID;
 public interface OnlineHearingRepository extends CrudRepository<OnlineHearing,UUID> {
 
     Optional<OnlineHearing> findByExternalRef(String externalRef);
+
+    @Transactional
     void deleteByExternalRef(String externalRef);
 }

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/AnswerService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/AnswerService.java
@@ -43,4 +43,8 @@ public class AnswerService {
 
         throw new EntityNotFoundException("Could not find the entity with id = " + answer.getAnswerId());
     }
+
+    public void deleteAnswer(Answer answer) {
+        answerRepository.delete(answer);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/OnlineHearingService.java
@@ -33,6 +33,10 @@ public class OnlineHearingService {
     }
 
     public void deleteOnlineHearing(final OnlineHearing onlineHearing) {
-        onlineHearingRepository.delete(onlineHearing);
+        onlineHearingRepository.deleteById(onlineHearing.getOnlineHearingId());
+    }
+
+    public void deleteByExternalRef(String externalRef) {
+        onlineHearingRepository.deleteByExternalRef(externalRef);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionService.java
@@ -42,4 +42,8 @@ public class QuestionService {
         question.addState(questionStateService.retrieveQuestionStateById(QuestionState.ISSUED));
         return questionRepository.save(question);
     }
+
+    public void deleteQuestion(Question question) {
+        questionRepository.delete(question);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/coh/service/AnswerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/coh/service/AnswerServiceTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
 public class AnswerServiceTest {
@@ -84,5 +84,12 @@ public class AnswerServiceTest {
         when(answerRepository.existsById(ONE)).thenReturn(true);
         when(answerRepository.save(answer)).thenReturn(answer);
         answerService.updateAnswerById(answer);
+    }
+
+    @Test
+    public void tesDelete() {
+        doNothing().when(answerRepository).delete(answer);
+        answerService.deleteAnswer(answer);
+        verify(answerRepository, times(1)).delete(answer);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/coh/service/OnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/coh/service/OnlineHearingServiceTest.java
@@ -64,9 +64,20 @@ public class OnlineHearingServiceTest {
 
     @Test
     public void testDeleteOnlineHearing() {
+        UUID uuid = UUID.randomUUID();
+        createdOnlineHearing.setOnlineHearingId(uuid);
         createdOnlineHearing.setExternalRef("foo");
-        doNothing().when(onlineHearingRepository).delete(createdOnlineHearing);
+        doNothing().when(onlineHearingRepository).deleteById(uuid);
         onlineHearingService.deleteOnlineHearing(createdOnlineHearing);
-        verify(onlineHearingRepository, times(1)).delete(createdOnlineHearing);
+        verify(onlineHearingRepository, times(1)).deleteById(uuid);
+    }
+
+    @Test
+    public void testDeleteByExternalRef() {
+        String externalRef = "foo";
+        createdOnlineHearing.setExternalRef(externalRef);
+        doNothing().when(onlineHearingRepository).deleteByExternalRef(externalRef);
+        onlineHearingService.deleteByExternalRef(externalRef);
+        verify(onlineHearingRepository, times(1)).deleteByExternalRef(externalRef);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/coh/service/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/coh/service/QuestionServiceTest.java
@@ -16,9 +16,7 @@ import uk.gov.hmcts.reform.coh.repository.QuestionRepository;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
 public class QuestionServiceTest {
@@ -79,5 +77,12 @@ public class QuestionServiceTest {
         verify(questionRepository, times(1)).findById(ONE);
         assertEquals("Correct state", issued, newQuestion.getQuestionState());
         assertEquals("Event logged", 1, newQuestion.getQuestionStateHistories().size());
+    }
+
+    @Test
+    public void tesDelete() {
+        doNothing().when(questionRepository).delete(question);
+        questionService.deleteQuestion(question);
+        verify(questionRepository, times(1)).delete(question);
     }
 }


### PR DESCRIPTION
These fixes ensure that test data is deleted from after cucumber test runs.

The important change is to src/aat/resources/application.yaml which now points to Postgres instead of H2.

The rest of the changes are really just cleaning up the testing "clean up" code