### PR TITLE
Change question state to issued without sending notification

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/service/QuestionService.java
@@ -85,7 +85,9 @@ public class QuestionService {
 
         if(proposedState.getState().equals("ISSUED")) {
             if (questionState.getQuestionStateId() != QuestionState.ISSUED) {
-                issueQuestion(currentQuestion);
+                QuestionState issuedQuestionState = questionStateService.retrieveQuestionStateById(QuestionState.ISSUED);
+                currentQuestion.addState(issuedQuestionState);
+                questionRepository.save(currentQuestion);
             }
         }else{
             // Add code to update question text / body ect here (NOT THIS BRANCH)


### PR DESCRIPTION
We should only send a notification to the jurisdiction when the question round is issued, not individual questions.