### PR TITLE
Use Spring DI for instantiating RestTemplate object

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/config/AppConfiguration.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/config/AppConfiguration.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.coh.functional.bdd.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestTrustManager;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+@TestConfiguration
+public class AppConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        return new RestTemplate(TestTrustManager.getInstance().getTestRequestFactory());
+    }
+}

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/AnswerSteps.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.reform.coh.controller.question.QuestionRequest;
 import uk.gov.hmcts.reform.coh.domain.Answer;
 import uk.gov.hmcts.reform.coh.domain.OnlineHearing;
 import uk.gov.hmcts.reform.coh.domain.Question;
+import uk.gov.hmcts.reform.coh.functional.bdd.config.AppConfiguration;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
 import uk.gov.hmcts.reform.coh.repository.OnlineHearingPanelMemberRepository;
 import uk.gov.hmcts.reform.coh.repository.OnlineHearingRepository;
@@ -41,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration
-@SpringBootTest
+@SpringBootTest(classes = {AppConfiguration.class})
 public class AnswerSteps extends BaseSteps{
     private static final Logger log = LoggerFactory.getLogger(AnswerSteps.class);
 

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/ApiSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/ApiSteps.java
@@ -31,6 +31,7 @@ import uk.gov.hmcts.reform.coh.controller.onlinehearing.CreateOnlineHearingRespo
 import uk.gov.hmcts.reform.coh.controller.onlinehearing.OnlineHearingRequest;
 import uk.gov.hmcts.reform.coh.domain.*;
 import uk.gov.hmcts.reform.coh.events.EventTypes;
+import uk.gov.hmcts.reform.coh.functional.bdd.config.AppConfiguration;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestTrustManager;
 import uk.gov.hmcts.reform.coh.repository.*;
@@ -46,7 +47,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 @ContextConfiguration
-@SpringBootTest
+@SpringBootTest(classes = {AppConfiguration.class})
 public class ApiSteps extends BaseSteps {
     private static final Logger log = LoggerFactory.getLogger(ApiSteps.class);
 

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/BaseSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/BaseSteps.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.coh.domain.Decision;
 import uk.gov.hmcts.reform.coh.domain.OnlineHearing;
 import uk.gov.hmcts.reform.coh.domain.SessionEventForwardingRegister;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
-import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestTrustManager;
 import uk.gov.hmcts.reform.coh.repository.OnlineHearingPanelMemberRepository;
 import uk.gov.hmcts.reform.coh.repository.SessionEventForwardingRegisterRepository;
 import uk.gov.hmcts.reform.coh.service.DecisionService;
@@ -28,6 +27,7 @@ import java.util.UUID;
 public class BaseSteps {
     private static final Logger log = LoggerFactory.getLogger(BaseSteps.class);
 
+    @Autowired
     protected RestTemplate restTemplate;
 
     protected static final DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
@@ -60,8 +60,6 @@ public class BaseSteps {
     }
 
     public void setup() throws Exception {
-        restTemplate = new RestTemplate(TestTrustManager.getInstance().getTestRequestFactory());
-
         endpoints.put("online hearing", "/continuous-online-hearings");
         endpoints.put("decision", "/continuous-online-hearings/onlineHearing_id/decisions");
         endpoints.put("question", "/continuous-online-hearings/onlineHearing_id/questions");

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/DeadlineSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/DeadlineSteps.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.client.ResponseErrorHandler;
 import uk.gov.hmcts.reform.coh.controller.question.AllQuestionsResponse;
 import uk.gov.hmcts.reform.coh.controller.question.QuestionResponse;
+import uk.gov.hmcts.reform.coh.functional.bdd.config.AppConfiguration;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
 import uk.gov.hmcts.reform.coh.schedule.notifiers.EventNotifierJob;
 
@@ -30,7 +31,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 
 @ContextConfiguration
-@SpringBootTest
+@SpringBootTest(classes = {AppConfiguration.class})
 public class DeadlineSteps extends BaseSteps {
 
     @Autowired

--- a/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/QuestionSteps.java
+++ b/src/aat/java/uk/gov/hmcts/reform/coh/functional/bdd/steps/QuestionSteps.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.reform.coh.domain.Jurisdiction;
 import uk.gov.hmcts.reform.coh.domain.OnlineHearing;
 import uk.gov.hmcts.reform.coh.domain.Question;
 import uk.gov.hmcts.reform.coh.domain.QuestionStateHistory;
+import uk.gov.hmcts.reform.coh.functional.bdd.config.AppConfiguration;
 import uk.gov.hmcts.reform.coh.functional.bdd.utils.TestContext;
 import uk.gov.hmcts.reform.coh.repository.JurisdictionRepository;
 import uk.gov.hmcts.reform.coh.repository.OnlineHearingPanelMemberRepository;
@@ -42,7 +43,7 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
 @ContextConfiguration
-@SpringBootTest
+@SpringBootTest(classes = {AppConfiguration.class})
 public class QuestionSteps extends BaseSteps{
     private static final Logger log = LoggerFactory.getLogger(QuestionSteps.class);
 

--- a/src/main/java/uk/gov/hmcts/reform/coh/config/AppConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/config/AppConfiguration.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.coh.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/coh/schedule/notifiers/BasicJsonNotificationForwarder.java
+++ b/src/main/java/uk/gov/hmcts/reform/coh/schedule/notifiers/BasicJsonNotificationForwarder.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.coh.schedule.notifiers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -36,6 +37,9 @@ public class BasicJsonNotificationForwarder implements NotificationForwarder<Not
     @Value("${base-urls.test-url}")
     String baseUrl;
 
+    @Autowired
+    private RestTemplate restTemplate;
+
     @Override
     public ResponseEntity sendEndpoint(SessionEventForwardingRegister register, NotificationRequest notificationRequest) throws NotificationException {
 
@@ -44,7 +48,6 @@ public class BasicJsonNotificationForwarder implements NotificationForwarder<Not
         ResponseEntity response = null;
         try {
             log.info(String.format("Sending request to %s", endpoint));
-            RestTemplate restTemplate = getRestTemplate();
             HttpEntity<String> request = new HttpEntity<>( mapper.writeValueAsString(notificationRequest), URL_ENCODED_HEADER);
             response = restTemplate.exchange(endpoint, HttpMethod.POST, request, String.class);
             log.info(String.format("Endpoint responded with %s", response.getStatusCodeValue()));
@@ -72,6 +75,6 @@ public class BasicJsonNotificationForwarder implements NotificationForwarder<Not
     }
 
     public RestTemplate getRestTemplate() {
-        return new RestTemplate();
+        return restTemplate;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/coh/schedule/notifiers/BasicJsonNotificationForwarderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/coh/schedule/notifiers/BasicJsonNotificationForwarderTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.coh.domain.SessionEventForwardingRegister;
@@ -52,6 +53,7 @@ public class BasicJsonNotificationForwarderTest {
         forwarder = Mockito.spy(BasicJsonNotificationForwarder.class);
 
         restTemplate = Mockito.mock(RestTemplate.class);
+        ReflectionTestUtils.setField(forwarder, "restTemplate", restTemplate);
 
         mapper = Mockito.mock(ObjectMapper.class);
 


### PR DESCRIPTION
Tests in AAT environment fail due to strict SSL checking.